### PR TITLE
Fix crash, background blending, generalize default audio device

### DIFF
--- a/mpv.conf
+++ b/mpv.conf
@@ -15,7 +15,7 @@ window-dragging=no
 geometry=1280x720
 mute
 image-display-duration=inf
-alpha=yes
+alpha=blend
 background=0.1/0.5
 script-opts=music-player-mode=client
 script=~~/scripts/music-client-main.lua

--- a/mpv.conf
+++ b/mpv.conf
@@ -24,6 +24,6 @@ script=~~/scripts/music-client-receiver.lua
 [server]
 profile=client-server-common
 force-window=no
-audio-device=pulse/headphones
+audio-device=auto
 script-opts=music-player-mode=server
 script=~~/scripts/music-server.lua

--- a/scripts/music-client-main.lua
+++ b/scripts/music-client-main.lua
@@ -969,7 +969,7 @@ do
         local end_x = waveform_position[1] + waveform_size[1]
         local current_x = nil
 
-        if not scrubbing then
+        if not scrubbing and properties["chapter-list"] and #properties["chapter-list"] > 0 then
             local _, norm_x  = get_chapter_with_snap({mp.get_mouse_pos()}, properties["chapter-list"], duration)
             cursor_x = norm_x and (norm_x * waveform_size[1] + waveform_position[1]) or cursor_x
         end

--- a/scripts/music-client-main.lua
+++ b/scripts/music-client-main.lua
@@ -1364,7 +1364,7 @@ do
         local is_play = not is_pause
         local is_mute = properties["mute"]
         local is_speakers = properties["audio-device"] == 'pulse/speakers'
-        local is_headphones = properties["audio-device"] == 'pulse/headphones'
+        local is_headphones = properties["audio-device"] == 'auto'
         local current_volume = properties["volume"] / 100
 
         local def = player_opts.controls_default_color
@@ -1497,7 +1497,7 @@ do
         elseif button == speakers then
             send_to_server({"set", "audio-device", "pulse/speakers"})
         elseif button == headphones then
-            send_to_server({"set", "audio-device", "pulse/headphones"})
+            send_to_server({"set", "audio-device", "auto"})
         elseif button == mute then
             send_to_server({"cycle", "mute"})
         end
@@ -1507,7 +1507,7 @@ do
         {"MBTN_LEFT", press_button, {complex=true, repeatable=false}},
         {"m", function() send_to_server({"cycle", "mute"}) end, {}},
         {"s", function() send_to_server({"set", "audio-device", "pulse/speakers"}) end, {}},
-        {"h", function() send_to_server({"set", "audio-device", "pulse/headphones"}) end, {}},
+        {"h", function() send_to_server({"set", "audio-device", "auto"}) end, {}},
         {"RIGHT", function() send_to_server({"add", "chapter", 1}) end, {}},
         {"LEFT", function() send_to_server({"add", "chapter", -1}) end, {}},
         {"UP", function() send_to_server({"add", "volume", 5}) end, {repeatable=true}},


### PR DESCRIPTION
Feel free to cherrypick if you think any of these changes are not relevant.

d014882: `alpha=yes` renders an overextended seekbar background on systems without compositor alpha blending.  
Screenshots: https://i.imgur.com/awTx0z4.png / https://i.imgur.com/DtOXDwX.png  
I traced this back to set_waveform_position, which feeds overextended dimensions to set_video_position.  
Adjusting dimensions to better match the actual seekbar cause the waveform to shrink https://i.imgur.com/t8FNnmA.png  
For this reason, and because the screenshot in the repo doesn't show this background at all, I concluded it was unintended.  
`alpha=blend` fixes it. I don't know if this extra background also renders on compositors with blending when `alpha=yes`.

cc203b3: It took me a while to realize why tracks wouldn't start at all, a better default that doesn't rely on a specific pulseaudio configuration is preferable.  
`speakers` button is unchanged, as there doesn't seem to be a universal way to target speakers.

fada4ec: This is a race condition, I only encountered it once.